### PR TITLE
make kinesis source metric easier to read in datadog flink-connect-aws connector

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -20,6 +20,6 @@
   </component>
   <component name="VcsDirectoryMappings">
     <mapping directory="$PROJECT_DIR$" vcs="Git" />
-    <mapping directory="$PROJECT_DIR$/tools/releasing/shared" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/tools/releasing/shared" vcs="" />
   </component>
 </project>

--- a/docs/data/dynamodb.yml
+++ b/docs/data/dynamodb.yml
@@ -16,7 +16,7 @@
 # limitations under the License.
 ################################################################################
 
-version: 5.1-SNAPSHOT
+version: 5.1.tubi-remove-logging
 variants:
   - maven: flink-connector-dynamodb
     sql_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-sql-connector-dynamodb/$full_version/flink-sql-connector-dynamodb-$full_version.jar

--- a/docs/data/firehose.yml
+++ b/docs/data/firehose.yml
@@ -16,7 +16,7 @@
 # limitations under the License.
 ################################################################################
 
-version: 5.1-SNAPSHOT
+version: 5.1.tubi-remove-logging
 variants:
   - maven: flink-connector-aws-kinesis-firehose
     sql_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-sql-connector-aws-kinesis-firehose/$full_version/flink-sql-connector-aws-kinesis-firehose-$full_version.jar

--- a/docs/data/kinesis.yml
+++ b/docs/data/kinesis.yml
@@ -16,7 +16,7 @@
 # limitations under the License.
 ################################################################################
 
-version: 5.1-SNAPSHOT
+version: 5.1.tubi-remove-logging
 variants:
   - maven: flink-connector-kinesis
     sql_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-sql-connector-kinesis/$full_version/flink-sql-connector-kinesis-$full_version.jar

--- a/flink-connector-aws-base/pom.xml
+++ b/flink-connector-aws-base/pom.xml
@@ -26,7 +26,7 @@ under the License.
     <parent>
         <groupId>org.apache.flink</groupId>
         <artifactId>flink-connector-aws</artifactId>
-        <version>5.1-SNAPSHOT</version>
+        <version>5.1.tubi-remove-logging</version>
     </parent>
 
     <artifactId>flink-connector-aws-base</artifactId>

--- a/flink-connector-aws-e2e-tests/flink-connector-aws-kinesis-firehose-e2e-tests/pom.xml
+++ b/flink-connector-aws-e2e-tests/flink-connector-aws-kinesis-firehose-e2e-tests/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <artifactId>flink-connector-aws-e2e-tests-parent</artifactId>
         <groupId>org.apache.flink</groupId>
-        <version>5.1-SNAPSHOT</version>
+        <version>5.1.tubi-remove-logging</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/flink-connector-aws-e2e-tests/flink-connector-aws-kinesis-streams-e2e-tests/pom.xml
+++ b/flink-connector-aws-e2e-tests/flink-connector-aws-kinesis-streams-e2e-tests/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <artifactId>flink-connector-aws-e2e-tests-parent</artifactId>
         <groupId>org.apache.flink</groupId>
-        <version>5.1-SNAPSHOT</version>
+        <version>5.1.tubi-remove-logging</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/flink-connector-aws-e2e-tests/flink-connector-aws-sqs-e2e-tests/pom.xml
+++ b/flink-connector-aws-e2e-tests/flink-connector-aws-sqs-e2e-tests/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <artifactId>flink-connector-aws-e2e-tests-parent</artifactId>
         <groupId>org.apache.flink</groupId>
-        <version>5.1-SNAPSHOT</version>
+        <version>5.1.tubi-remove-logging</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/flink-connector-aws-e2e-tests/flink-connector-kinesis-e2e-tests/pom.xml
+++ b/flink-connector-aws-e2e-tests/flink-connector-kinesis-e2e-tests/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <artifactId>flink-connector-aws-e2e-tests-parent</artifactId>
         <groupId>org.apache.flink</groupId>
-        <version>5.1-SNAPSHOT</version>
+        <version>5.1.tubi-remove-logging</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/flink-connector-aws-e2e-tests/flink-formats-avro-glue-schema-registry-e2e-tests/pom.xml
+++ b/flink-connector-aws-e2e-tests/flink-formats-avro-glue-schema-registry-e2e-tests/pom.xml
@@ -25,7 +25,7 @@ under the License.
     <parent>
         <groupId>org.apache.flink</groupId>
         <artifactId>flink-connector-aws-e2e-tests-parent</artifactId>
-        <version>5.1-SNAPSHOT</version>
+        <version>5.1.tubi-remove-logging</version>
     </parent>
 
     <artifactId>flink-formats-avro-glue-schema-registry-e2e-tests</artifactId>

--- a/flink-connector-aws-e2e-tests/flink-formats-json-glue-schema-registry-e2e-tests/pom.xml
+++ b/flink-connector-aws-e2e-tests/flink-formats-json-glue-schema-registry-e2e-tests/pom.xml
@@ -25,7 +25,7 @@ under the License.
     <parent>
         <groupId>org.apache.flink</groupId>
         <artifactId>flink-connector-aws-e2e-tests-parent</artifactId>
-        <version>5.1-SNAPSHOT</version>
+        <version>5.1.tubi-remove-logging</version>
     </parent>
 
     <artifactId>flink-formats-json-glue-schema-registry-e2e-tests</artifactId>

--- a/flink-connector-aws-e2e-tests/pom.xml
+++ b/flink-connector-aws-e2e-tests/pom.xml
@@ -26,7 +26,7 @@ under the License.
     <parent>
         <groupId>org.apache.flink</groupId>
         <artifactId>flink-connector-aws</artifactId>
-        <version>5.1-SNAPSHOT</version>
+        <version>5.1.tubi-remove-logging</version>
     </parent>
 
     <artifactId>flink-connector-aws-e2e-tests-parent</artifactId>

--- a/flink-connector-aws/flink-connector-aws-kinesis-firehose/pom.xml
+++ b/flink-connector-aws/flink-connector-aws-kinesis-firehose/pom.xml
@@ -26,7 +26,7 @@ under the License.
     <parent>
         <groupId>org.apache.flink</groupId>
         <artifactId>flink-connector-aws-parent</artifactId>
-        <version>5.1-SNAPSHOT</version>
+        <version>5.1.tubi-remove-logging</version>
     </parent>
 
     <artifactId>flink-connector-aws-kinesis-firehose</artifactId>

--- a/flink-connector-aws/flink-connector-aws-kinesis-streams/pom.xml
+++ b/flink-connector-aws/flink-connector-aws-kinesis-streams/pom.xml
@@ -26,7 +26,7 @@ under the License.
     <parent>
         <groupId>org.apache.flink</groupId>
         <artifactId>flink-connector-aws-parent</artifactId>
-        <version>5.1-SNAPSHOT</version>
+        <version>5.1.tubi-remove-logging</version>
     </parent>
 
     <artifactId>flink-connector-aws-kinesis-streams</artifactId>

--- a/flink-connector-aws/flink-connector-dynamodb/pom.xml
+++ b/flink-connector-aws/flink-connector-dynamodb/pom.xml
@@ -26,7 +26,7 @@ under the License.
     <parent>
         <groupId>org.apache.flink</groupId>
         <artifactId>flink-connector-aws-parent</artifactId>
-        <version>5.1-SNAPSHOT</version>
+        <version>5.1.tubi-remove-logging</version>
     </parent>
 
     <artifactId>flink-connector-dynamodb</artifactId>

--- a/flink-connector-aws/flink-connector-kinesis/pom.xml
+++ b/flink-connector-aws/flink-connector-kinesis/pom.xml
@@ -26,7 +26,7 @@ under the License.
     <parent>
         <groupId>org.apache.flink</groupId>
         <artifactId>flink-connector-aws-parent</artifactId>
-        <version>5.1-SNAPSHOT</version>
+        <version>5.1.tubi-remove-logging</version>
     </parent>
 
     <artifactId>flink-connector-kinesis</artifactId>

--- a/flink-connector-aws/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/KinesisDataFetcher.java
+++ b/flink-connector-aws/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/KinesisDataFetcher.java
@@ -547,8 +547,8 @@ public class KinesisDataFetcher<T> {
         // added by the
         //     consumer using a restored state checkpoint
         for (int seededStateIndex = 0;
-             seededStateIndex < subscribedShardsState.size();
-             seededStateIndex++) {
+                seededStateIndex < subscribedShardsState.size();
+                seededStateIndex++) {
             KinesisStreamShardState seededShardState = subscribedShardsState.get(seededStateIndex);
 
             // only start a consuming thread if the seeded subscribed shard has not been completely
@@ -585,7 +585,7 @@ public class KinesisDataFetcher<T> {
                                 //
                                 // streamShardHandle.getShard().getShardId())
                                 //                                                .addGroup("user")
-                        ));
+                                ));
                 shardConsumersExecutor.submit(
                         createShardConsumer(
                                 seededStateIndex,
@@ -735,7 +735,7 @@ public class KinesisDataFetcher<T> {
                                 //
                                 // streamShardHandle.getShard().getShardId())
                                 //                                                .addGroup("user")
-                        ));
+                                ));
                 shardConsumersExecutor.submit(
                         createShardConsumer(
                                 newStateIndex,
@@ -1163,8 +1163,8 @@ public class KinesisDataFetcher<T> {
             // consider only active shards, or those that would advance the watermark
             if (w != null
                     && (e.getValue().lastUpdated >= idleTime
-                    || e.getValue().emitQueue.getSize() > 0
-                    || w.getTimestamp() > lastWatermark)) {
+                            || e.getValue().emitQueue.getSize() > 0
+                            || w.getTimestamp() > lastWatermark)) {
                 potentialWatermark = Math.min(potentialWatermark, w.getTimestamp());
                 // for sync, use the watermark of the next record, when available
                 // otherwise watermark may stall when record is blocked by synchronization
@@ -1396,7 +1396,7 @@ public class KinesisDataFetcher<T> {
      * @return the initial map for subscribedStreamsToLastDiscoveredShardIds
      */
     protected static HashMap<String, String>
-    createInitialSubscribedStreamsToLastDiscoveredShardsState(List<String> streams) {
+            createInitialSubscribedStreamsToLastDiscoveredShardsState(List<String> streams) {
         HashMap<String, String> initial = new HashMap<>();
         for (String stream : streams) {
             initial.put(stream, null);

--- a/flink-connector-aws/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/KinesisDataFetcher.java
+++ b/flink-connector-aws/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/KinesisDataFetcher.java
@@ -547,8 +547,8 @@ public class KinesisDataFetcher<T> {
         // added by the
         //     consumer using a restored state checkpoint
         for (int seededStateIndex = 0;
-                seededStateIndex < subscribedShardsState.size();
-                seededStateIndex++) {
+             seededStateIndex < subscribedShardsState.size();
+             seededStateIndex++) {
             KinesisStreamShardState seededShardState = subscribedShardsState.get(seededStateIndex);
 
             // only start a consuming thread if the seeded subscribed shard has not been completely
@@ -574,15 +574,18 @@ public class KinesisDataFetcher<T> {
                         RuntimeContextInitializationContextAdapters.deserializationAdapter(
                                 runtimeContext,
                                 // ignore the provided metric group
-                                metricGroup ->
-                                        consumerMetricGroup
-                                                .addGroup(
-                                                        "subtaskId",
-                                                        String.valueOf(indexOfThisConsumerSubtask))
-                                                .addGroup(
-                                                        "shardId",
-                                                        streamShardHandle.getShard().getShardId())
-                                                .addGroup("user")));
+                                metricGroup -> consumerMetricGroup
+                                //                                                .addGroup(
+                                //
+                                // "subtaskId",
+                                //
+                                // String.valueOf(indexOfThisConsumerSubtask))
+                                //                                                .addGroup(
+                                //                                                        "shardId",
+                                //
+                                // streamShardHandle.getShard().getShardId())
+                                //                                                .addGroup("user")
+                        ));
                 shardConsumersExecutor.submit(
                         createShardConsumer(
                                 seededStateIndex,
@@ -721,15 +724,18 @@ public class KinesisDataFetcher<T> {
                         RuntimeContextInitializationContextAdapters.deserializationAdapter(
                                 runtimeContext,
                                 // ignore the provided metric group
-                                metricGroup ->
-                                        consumerMetricGroup
-                                                .addGroup(
-                                                        "subtaskId",
-                                                        String.valueOf(indexOfThisConsumerSubtask))
-                                                .addGroup(
-                                                        "shardId",
-                                                        streamShardHandle.getShard().getShardId())
-                                                .addGroup("user")));
+                                metricGroup -> consumerMetricGroup
+                                //                                                .addGroup(
+                                //
+                                // "subtaskId",
+                                //
+                                // String.valueOf(indexOfThisConsumerSubtask))
+                                //                                                .addGroup(
+                                //                                                        "shardId",
+                                //
+                                // streamShardHandle.getShard().getShardId())
+                                //                                                .addGroup("user")
+                        ));
                 shardConsumersExecutor.submit(
                         createShardConsumer(
                                 newStateIndex,
@@ -1157,8 +1163,8 @@ public class KinesisDataFetcher<T> {
             // consider only active shards, or those that would advance the watermark
             if (w != null
                     && (e.getValue().lastUpdated >= idleTime
-                            || e.getValue().emitQueue.getSize() > 0
-                            || w.getTimestamp() > lastWatermark)) {
+                    || e.getValue().emitQueue.getSize() > 0
+                    || w.getTimestamp() > lastWatermark)) {
                 potentialWatermark = Math.min(potentialWatermark, w.getTimestamp());
                 // for sync, use the watermark of the next record, when available
                 // otherwise watermark may stall when record is blocked by synchronization
@@ -1331,13 +1337,13 @@ public class KinesisDataFetcher<T> {
      */
     private MetricGroup registerShardMetricGroup(
             final MetricGroup metricGroup, final KinesisStreamShardState shardState) {
-        return metricGroup
-                .addGroup(
-                        KinesisConsumerMetricConstants.STREAM_METRICS_GROUP,
-                        shardState.getStreamShardHandle().getStreamName())
-                .addGroup(
-                        KinesisConsumerMetricConstants.SHARD_METRICS_GROUP,
-                        shardState.getStreamShardHandle().getShard().getShardId());
+        return metricGroup;
+        //                .addGroup(
+        //                        KinesisConsumerMetricConstants.STREAM_METRICS_GROUP,
+        //                        shardState.getStreamShardHandle().getStreamName())
+        //                .addGroup(
+        //                        KinesisConsumerMetricConstants.SHARD_METRICS_GROUP,
+        //                        shardState.getStreamShardHandle().getShard().getShardId());
     }
 
     // ------------------------------------------------------------------------
@@ -1390,7 +1396,7 @@ public class KinesisDataFetcher<T> {
      * @return the initial map for subscribedStreamsToLastDiscoveredShardIds
      */
     protected static HashMap<String, String>
-            createInitialSubscribedStreamsToLastDiscoveredShardsState(List<String> streams) {
+    createInitialSubscribedStreamsToLastDiscoveredShardsState(List<String> streams) {
         HashMap<String, String> initial = new HashMap<>();
         for (String stream : streams) {
             initial.put(stream, null);

--- a/flink-connector-aws/flink-connector-sqs/pom.xml
+++ b/flink-connector-aws/flink-connector-sqs/pom.xml
@@ -26,7 +26,7 @@ under the License.
     <parent>
         <groupId>org.apache.flink</groupId>
         <artifactId>flink-connector-aws-parent</artifactId>
-        <version>5.1-SNAPSHOT</version>
+        <version>5.1.tubi-remove-logging</version>
     </parent>
 
     <artifactId>flink-connector-sqs</artifactId>

--- a/flink-connector-aws/flink-sql-connector-aws-kinesis-firehose/pom.xml
+++ b/flink-connector-aws/flink-sql-connector-aws-kinesis-firehose/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.flink</groupId>
         <artifactId>flink-connector-aws-parent</artifactId>
-        <version>5.1-SNAPSHOT</version>
+        <version>5.1.tubi-remove-logging</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/flink-connector-aws/flink-sql-connector-aws-kinesis-streams/pom.xml
+++ b/flink-connector-aws/flink-sql-connector-aws-kinesis-streams/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.flink</groupId>
         <artifactId>flink-connector-aws-parent</artifactId>
-        <version>5.1-SNAPSHOT</version>
+        <version>5.1.tubi-remove-logging</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/flink-connector-aws/flink-sql-connector-dynamodb/pom.xml
+++ b/flink-connector-aws/flink-sql-connector-dynamodb/pom.xml
@@ -26,7 +26,7 @@ under the License.
     <parent>
         <groupId>org.apache.flink</groupId>
         <artifactId>flink-connector-aws-parent</artifactId>
-        <version>5.1-SNAPSHOT</version>
+        <version>5.1.tubi-remove-logging</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/flink-connector-aws/flink-sql-connector-kinesis/pom.xml
+++ b/flink-connector-aws/flink-sql-connector-kinesis/pom.xml
@@ -26,7 +26,7 @@ under the License.
     <parent>
         <groupId>org.apache.flink</groupId>
         <artifactId>flink-connector-aws-parent</artifactId>
-        <version>5.1-SNAPSHOT</version>
+        <version>5.1.tubi-remove-logging</version>
     </parent>
 
     <artifactId>flink-sql-connector-kinesis</artifactId>

--- a/flink-connector-aws/pom.xml
+++ b/flink-connector-aws/pom.xml
@@ -26,7 +26,7 @@ under the License.
     <parent>
         <artifactId>flink-connector-aws</artifactId>
         <groupId>org.apache.flink</groupId>
-        <version>5.1-SNAPSHOT</version>
+        <version>5.1.tubi-remove-logging</version>
     </parent>
 
     <artifactId>flink-connector-aws-parent</artifactId>

--- a/flink-formats-aws/flink-avro-glue-schema-registry/pom.xml
+++ b/flink-formats-aws/flink-avro-glue-schema-registry/pom.xml
@@ -25,7 +25,7 @@ under the License.
     <parent>
         <groupId>org.apache.flink</groupId>
         <artifactId>flink-formats-aws-parent</artifactId>
-        <version>5.1-SNAPSHOT</version>
+        <version>5.1.tubi-remove-logging</version>
     </parent>
 
     <artifactId>flink-avro-glue-schema-registry</artifactId>

--- a/flink-formats-aws/flink-json-glue-schema-registry/pom.xml
+++ b/flink-formats-aws/flink-json-glue-schema-registry/pom.xml
@@ -25,7 +25,7 @@ under the License.
     <parent>
         <groupId>org.apache.flink</groupId>
         <artifactId>flink-formats-aws-parent</artifactId>
-        <version>5.1-SNAPSHOT</version>
+        <version>5.1.tubi-remove-logging</version>
     </parent>
 
     <artifactId>flink-json-glue-schema-registry</artifactId>

--- a/flink-formats-aws/pom.xml
+++ b/flink-formats-aws/pom.xml
@@ -26,7 +26,7 @@ under the License.
     <parent>
         <artifactId>flink-connector-aws</artifactId>
         <groupId>org.apache.flink</groupId>
-        <version>5.1-SNAPSHOT</version>
+        <version>5.1.tubi-remove-logging</version>
     </parent>
 
     <artifactId>flink-formats-aws-parent</artifactId>

--- a/flink-python/pom.xml
+++ b/flink-python/pom.xml
@@ -26,7 +26,7 @@ under the License.
     <parent>
         <groupId>org.apache.flink</groupId>
         <artifactId>flink-connector-aws</artifactId>
-        <version>5.1-SNAPSHOT</version>
+        <version>5.1.tubi-remove-logging</version>
     </parent>
 
     <artifactId>flink-python-connector-aws</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@ under the License.
 
     <groupId>org.apache.flink</groupId>
     <artifactId>flink-connector-aws</artifactId>
-    <version>5.1-SNAPSHOT</version>
+    <version>5.1.tubi-remove-logging</version>
 
     <name>Flink : Connectors : AWS</name>
     <packaging>pom</packaging>


### PR DESCRIPTION
for the master code metric send logic, it will add shard_id in `flink.operator.KinesisConsumer.millisBehindLatest.$shard_id`; this way, we can only set the dashboard for each shard; this is hard to debug when we want to see the latency. My change is to remove unnecessary conditions in the metric name but make it in the tag level. 